### PR TITLE
Refactor Samplers to be More Extensible

### DIFF
--- a/bayesiantesting/kernels/bayes.py
+++ b/bayesiantesting/kernels/bayes.py
@@ -192,12 +192,12 @@ class BaseModelEvidenceKernel:
 
         Returns
         -------
-        tuple of tuple:
+        tuple of tuple
             The results of each window in the form of a tuple
             of numpy arrays (trace, log_p_trace, d_log_p_d_lamda).
-        float:
+        float
             The integrated model evidence.
-        float:
+        float
             The standard error in the model evidence.
         """
 

--- a/bayesiantesting/kernels/mcmc.py
+++ b/bayesiantesting/kernels/mcmc.py
@@ -6,12 +6,11 @@ import json
 import os
 
 import numpy as np
-import torch
 from matplotlib import pyplot
 from tqdm import tqdm
 
+from bayesiantesting.kernels.samplers import MetropolisSampler
 from bayesiantesting.models import Model, ModelCollection
-from bayesiantesting.utils import distributions as distributions
 
 
 class MCMCSimulation:
@@ -50,7 +49,7 @@ class MCMCSimulation:
         save_trace_plots: bool
             If true, plots of the traces will be saved in the output
             directory.
-        sampler: optional
+        sampler: Sampler, optional
             The sampler to use for in-model proposals.
         """
 
@@ -77,6 +76,9 @@ class MCMCSimulation:
         self._initial_log_p = None
 
         self._sampler = sampler
+
+        if self._sampler is not None:
+            self._sampler.log_p_function = self._evaluate_log_p
 
     def _validate_parameter_shapes(self, initial_parameters, initial_model_index):
 
@@ -122,6 +124,13 @@ class MCMCSimulation:
             self._initial_values
         )
 
+        # Make sure we have a sampler set
+        if self._sampler is None:
+
+            self._sampler = MetropolisSampler(self._evaluate_log_p,
+                                              self._model_collection,
+                                              self._initial_values / 100)
+
         # Initialize the trace vectors
         total_steps = self.steps + self.warm_up_steps
 
@@ -154,8 +163,6 @@ class MCMCSimulation:
             (self._model_collection.n_models, self._model_collection.n_models)
         )
 
-        proposal_scales = np.asarray(self._initial_values) / 100
-
         print("Running Simulation...")
         print("==============================")
 
@@ -179,7 +186,6 @@ class MCMCSimulation:
             new_parameters, new_model_index, new_log_p, acceptance = self._run_step(
                 current_parameters,
                 current_model_index,
-                proposal_scales,
                 current_log_p,
                 move_proposals,
                 move_acceptances,
@@ -200,12 +206,6 @@ class MCMCSimulation:
             log_p_trace[i + 1] = new_log_p
             percent_deviation_trace.append(new_percent_deviation)
 
-            if (not (i + 1) % self._tune_frequency) and (i < self.warm_up_steps):
-
-                proposal_scales = self._tune_proposals(
-                    move_proposals, move_acceptances, proposal_scales
-                )
-
             if i == self.warm_up_steps:
 
                 move_proposals = np.zeros(
@@ -214,6 +214,8 @@ class MCMCSimulation:
                 move_acceptances = np.zeros(
                     (self._model_collection.n_models, self._model_collection.n_models)
                 )
+
+                self._sampler.reset_counters()
 
             if progress_bar is not None and progress_bar is not False:
                 progress_bar.update()
@@ -252,7 +254,6 @@ class MCMCSimulation:
             percent_deviation_trace_arrays,
             move_proposals,
             move_acceptances,
-            proposal_scales,
         )
 
         return trace, log_p_trace, percent_deviation_trace_arrays
@@ -261,7 +262,6 @@ class MCMCSimulation:
         self,
         current_parameters,
         current_model_index,
-        proposal_scales,
         current_log_p,
         move_proposals,
         move_acceptances,
@@ -270,38 +270,16 @@ class MCMCSimulation:
 
         proposed_parameters = current_parameters.copy()
 
-        if self._sampler is None:
-            # Perform a standard Metropolis–Hastings move.
-            proposed_parameters, proposed_log_p = self.parameter_proposal(
-                proposed_parameters, current_model_index, proposal_scales
-            )
-            alpha = proposed_log_p - current_log_p
-
-            acceptance = self._accept_reject(alpha)
-        else:
-            # Perform a more advanced sampler move.
-            proposed_parameters, acceptance = self._sampler.step(
-                current_parameters, adapt_moves
-            )
-
-            model = self._model_collection.models[current_model_index]
-            proposed_log_p = model.evaluate_log_posterior(proposed_parameters)
+        proposed_parameters, proposed_log_p, acceptance = self._sampler.step(
+            proposed_parameters, current_log_p, adapt_moves
+        )
 
         move_proposals[current_model_index, current_model_index] += 1
 
         if acceptance:
-
-            new_log_p = proposed_log_p
-            new_params = proposed_parameters
-
             move_acceptances[current_model_index, current_model_index] += 1
 
-        else:
-
-            new_log_p = current_log_p
-            new_params = current_parameters
-
-        return new_params, current_model_index, new_log_p, acceptance
+        return proposed_parameters, current_model_index, proposed_log_p, acceptance
 
     def _evaluate_log_p(self, parameters, model_index):
         """Evaluates the (possibly un-normalized) target distribution
@@ -321,43 +299,6 @@ class MCMCSimulation:
         """
         model = self._model_collection.models[model_index]
         return model.evaluate_log_posterior(parameters)
-
-    def parameter_proposal(
-        self, proposed_parameters, current_model_index, proposal_scales
-    ):
-
-        model = self._model_collection.models[current_model_index]
-
-        # Choose a random parameter to change
-        parameter_index = torch.randint(model.n_trainable_parameters, (1,))
-
-        # Sample the new parameters from a normal distribution.
-        proposed_parameters[parameter_index] = distributions.Normal(
-            proposed_parameters[parameter_index], proposal_scales[parameter_index]
-        ).sample()
-
-        proposed_log_p = self._evaluate_log_p(proposed_parameters, current_model_index)
-
-        return proposed_parameters, proposed_log_p
-
-    @staticmethod
-    def _accept_reject(alpha):
-
-        # Metropolis-Hastings accept/reject criteria
-        random_number = torch.rand((1,))
-        return torch.log(random_number).item() < alpha
-
-    @staticmethod
-    def _tune_proposals(move_proposals, move_acceptances, proposal_scales):
-
-        acceptance_rate = np.sum(move_acceptances) / np.sum(move_proposals)
-
-        if acceptance_rate < 0.2:
-            proposal_scales *= 0.9
-        elif acceptance_rate > 0.5:
-            proposal_scales *= 1.1
-
-        return proposal_scales
 
     def _print_statistics(self, move_proposals, move_acceptances):
 
@@ -405,7 +346,6 @@ class MCMCSimulation:
         percentage_deviations,
         move_proposals,
         move_acceptances,
-        proposal_scales,
     ):
         """Saves the results of the simulation to the output
         directory.
@@ -422,9 +362,6 @@ class MCMCSimulation:
             An array of the counts of the proposed moves.
         move_acceptances: numpy.ndarray
             An array of the counts of the accepted moves.
-        proposal_scales: numpy.ndarray
-            The scale of the gaussian distributions used
-            when proposing in model sampling moves.
         """
 
         # Make sure the output directory exists
@@ -435,9 +372,9 @@ class MCMCSimulation:
         self._save_traces(trace, log_p_trace, percentage_deviations)
 
         # Save the move statistics
-        self._save_statistics(move_proposals, move_acceptances, proposal_scales)
+        self._save_statistics(move_proposals, move_acceptances)
 
-    def _save_statistics(self, move_proposals, move_acceptances, proposal_scales):
+    def _save_statistics(self, move_proposals, move_acceptances):
         """Save statistics about the simulation.
 
         Parameters
@@ -446,13 +383,9 @@ class MCMCSimulation:
             An array of the counts of the proposed moves.
         move_acceptances: numpy.ndarray
             An array of the counts of the accepted moves.
-        proposal_scales: numpy.ndarray
-            The scale of the gaussian distributions used
-            when proposing in model sampling moves.
         """
         results = {
             "Proposed Moves": move_proposals.tolist(),
-            "Final Move SD": proposal_scales.tolist(),
             "Accepted Moves": move_acceptances.tolist(),
         }
 

--- a/bayesiantesting/kernels/mcmc.py
+++ b/bayesiantesting/kernels/mcmc.py
@@ -127,9 +127,9 @@ class MCMCSimulation:
         # Make sure we have a sampler set
         if self._sampler is None:
 
-            self._sampler = MetropolisSampler(self._evaluate_log_p,
-                                              self._model_collection,
-                                              self._initial_values / 100)
+            self._sampler = MetropolisSampler(
+                self._evaluate_log_p, self._model_collection, self._initial_values / 100
+            )
 
         # Initialize the trace vectors
         total_steps = self.steps + self.warm_up_steps

--- a/bayesiantesting/kernels/mcmc.py
+++ b/bayesiantesting/kernels/mcmc.py
@@ -128,7 +128,9 @@ class MCMCSimulation:
         if self._sampler is None:
 
             self._sampler = MetropolisSampler(
-                self._evaluate_log_p, self._model_collection, self._initial_values / 100
+                self._evaluate_log_p,
+                self._model_collection,
+                np.array([self._initial_values / 100]),
             )
 
         # Initialize the trace vectors
@@ -268,10 +270,8 @@ class MCMCSimulation:
         adapt_moves=False,
     ):
 
-        proposed_parameters = current_parameters.copy()
-
         proposed_parameters, proposed_log_p, acceptance = self._sampler.step(
-            proposed_parameters, current_log_p, adapt_moves
+            current_parameters, current_model_index, current_log_p, adapt_moves
         )
 
         move_proposals[current_model_index, current_model_index] += 1

--- a/bayesiantesting/kernels/mcmc.py
+++ b/bayesiantesting/kernels/mcmc.py
@@ -387,6 +387,7 @@ class MCMCSimulation:
         results = {
             "Proposed Moves": move_proposals.tolist(),
             "Accepted Moves": move_acceptances.tolist(),
+            "Sampler: ": self._sampler.get_statistics_dictionary(),
         }
 
         filename = os.path.join(self._output_directory_path, "statistics.json")

--- a/bayesiantesting/kernels/rjmc.py
+++ b/bayesiantesting/kernels/rjmc.py
@@ -38,13 +38,11 @@ class RJMCSimulation(MCMCSimulation):
             raise ValueError("The model must be a `ModelCollection`.")
 
         if not model_collection.n_models > 1:
+
             raise ValueError(
                 "The model collection must contain at least two "
                 "sub-models to jump between."
             )
-
-        if sampler is not None:
-            raise ValueError("Samplers cannot currently be used with RJMC")
 
         super().__init__(
             model_collection,
@@ -63,7 +61,6 @@ class RJMCSimulation(MCMCSimulation):
         self,
         current_parameters,
         current_model_index,
-        proposal_scales,
         current_log_p,
         move_proposals,
         move_acceptances,
@@ -92,22 +89,22 @@ class RJMCSimulation(MCMCSimulation):
                 + np.log(transition_probability)
             )
 
+            # Check for NaNs in the proposed state.
+            if proposed_log_p == math.nan:
+
+                alpha = -math.inf
+                proposed_log_p = -math.inf
+
+            # Apply the acceptance criteria.
+            random_number = torch.rand((1,)).item()
+            acceptance = np.log(random_number) < alpha
+
         else:
 
             # Propose an in-model move.
-            proposed_parameters, proposed_log_p = self.parameter_proposal(
-                proposed_parameters, proposed_model_index, proposal_scales
+            proposed_parameters, proposed_log_p, acceptance = self._sampler.step(
+                proposed_parameters, current_log_p, adapt
             )
-            alpha = proposed_log_p - current_log_p
-
-        # Check for NaNs in the proposed state.
-        if proposed_log_p == math.nan:
-
-            alpha = -math.inf
-            proposed_log_p = -math.inf
-
-        # Apply the acceptance criteria.
-        acceptance = self._accept_reject(alpha)
 
         move_proposals[current_model_index, proposed_model_index] += 1
 
@@ -156,191 +153,6 @@ class RJMCSimulation(MCMCSimulation):
             jacobian,
             transition_probability,
         )
-
-    # def Report(self, plotting=False, USE_BAR=False):
-    #     print("Proposed Moves:")
-    #     print(np.sum(self.move_proposals))
-    #     print(self.move_proposals)
-    #     print("==============================")
-    #     print("Successful Moves:")
-    #     print(self.move_acceptances)
-    #     print("==============================")
-    #     prob_matrix = self.move_acceptances / self.move_proposals
-    #     print("Ratio of successful moves")
-    #     print(prob_matrix)
-    #     print("==============================")
-    #     transition_matrix = np.ones((3, 3))
-    #     transition_matrix[0, 1] = (
-    #         self.move_acceptances[0, 1] / np.sum(self.move_proposals, 1)[0]
-    #     )
-    #     transition_matrix[0, 2] = (
-    #         self.move_acceptances[0, 2] / np.sum(self.move_proposals, 1)[0]
-    #     )
-    #     transition_matrix[1, 0] = (
-    #         self.move_acceptances[1, 0] / np.sum(self.move_proposals, 1)[1]
-    #     )
-    #     transition_matrix[1, 2] = (
-    #         self.move_acceptances[1, 2] / np.sum(self.move_proposals, 1)[1]
-    #     )
-    #     transition_matrix[2, 1] = (
-    #         self.move_acceptances[2, 1] / np.sum(self.move_proposals, 1)[2]
-    #     )
-    #     transition_matrix[2, 0] = (
-    #         self.move_acceptances[2, 0] / np.sum(self.move_proposals, 1)[2]
-    #     )
-    #     transition_matrix[0, 0] = 1 - transition_matrix[0, 1] - transition_matrix[0, 2]
-    #     transition_matrix[1, 1] = 1 - transition_matrix[1, 0] - transition_matrix[1, 2]
-    #     transition_matrix[2, 2] = 1 - transition_matrix[2, 0] - transition_matrix[2, 1]
-    #     print("Transition Matrix:")
-    #     print(transition_matrix)
-    #     print("==============================")
-    #     self.transition_matrix = transition_matrix
-    #
-    #     self.trace_tuned = self.trace[self.tune_for + 1 :]
-    #     self.logp_trace_tuned = self.logp_trace[self.tune_for + 1 :]
-    #     self.percent_dev_trace_tuned = self.percent_dev_trace[self.tune_for + 1 :]
-    #
-    #     self.lit_params, self.lit_devs = utils.import_literature_values(
-    #         "two", self.compound
-    #     )
-    #     trace_equil = self.trace_tuned
-    #     logp_trace_equil = self.logp_trace_tuned
-    #     percent_dev_trace_equil = self.percent_dev_trace_tuned
-    #     self.prob_conf = None
-    #     try:
-    #         self.prob_conf = utils.compute_multinomial_confidence_intervals(trace_equil)
-    #     except pymbar.utils.ParameterError:
-    #         print("Cannot compute confidence intervals due to only sampling one model")
-    #
-    #     # Converts the array with number of model parameters into an array with
-    #     # the number of times there was 1 parameter or 2 parameters
-    #     model_count = np.array(
-    #         [
-    #             len(trace_equil[trace_equil[:, 0] == 0]),
-    #             len(trace_equil[trace_equil[:, 0] == 1]),
-    #             len(trace_equil[trace_equil[:, 0] == 2]),
-    #         ]
-    #     )
-    #
-    #     prob_0 = 1.0 * model_count[0] / (len(trace_equil))
-    #     print(
-    #         "Percent that  model 0 is sampled: " + str(prob_0 * 100.0)
-    #     )  # The percent that use 1 parameter model
-    #
-    #     prob_1 = 1.0 * model_count[1] / (len(trace_equil))
-    #     print(
-    #         "Percent that model 1 is sampled: " + str(prob_1 * 100.0)
-    #     )  # The percent that use two center UA LJ
-    #
-    #     prob_2 = 1.0 * model_count[2] / (len(trace_equil))
-    #     print(
-    #         "Percent that model 2 is sampled: " + str(prob_2 * 100.0)
-    #     )  # The percent that use two center UA LJ
-    #     print("==============================")
-    #     self.prob = [prob_0, prob_1, prob_2]
-    #
-    #     self.Exp_ratio = [prob_0 / prob_1, prob_0 / prob_2]
-    #
-    #     if self.prob_conf is not None:
-    #         print("95% confidence intervals for probability", self.prob_conf)
-    #
-    #     self.unbiased_prob = utils.unbias_simulation(
-    #         np.asarray(self.biasing_factor), np.asarray(self.prob)
-    #     )
-    #     print("Unbiased probabilities")
-    #
-    #     print("Experimental sampling ratio:", self.Exp_ratio)
-    #     print("==============================")
-    #
-    #     print("Detailed Balance")
-    #
-    #     # These sets of numbers should be roughly equal to each other (If both
-    #     # models are sampled).  If not, big problem
-    #
-    #     print(prob_0 * transition_matrix[0, 1])
-    #     print(prob_1 * transition_matrix[1, 0])
-    #
-    #     print(prob_0 * transition_matrix[0, 2])
-    #     print(prob_2 * transition_matrix[2, 0])
-    #
-    #     print(prob_1 * transition_matrix[1, 2])
-    #     print(prob_2 * transition_matrix[2, 1])
-    #     print("==============================")
-    #     trace_model_0 = []
-    #     trace_model_1 = []
-    #     trace_model_2 = []
-    #     """
-    #     log_trace_0=[]
-    #     log_trace_1=[]
-    #     log_trace_2=[]
-    #     """
-    #     for i in range(np.size(trace_equil, 0)):
-    #         if trace_equil[i, 0] == 0:
-    #             trace_model_0.append(trace_equil[i])
-    #             # log_trace_0.append(logp_trace[i])
-    #         elif trace_equil[i, 0] == 1:
-    #             trace_model_1.append(trace_equil[i])
-    #             # log_trace_1.append(logp_trace[i])
-    #         elif trace_equil[i, 0] == 2:
-    #             trace_model_2.append(trace_equil[i])
-    #             # log_trace_2.append(logp_trace[i])
-    #
-    #     self.trace_model_0 = np.asarray(trace_model_0)
-    #     self.trace_model_1 = np.asarray(trace_model_1)
-    #     self.trace_model_2 = np.asarray(trace_model_2)
-    #
-    #     self.BAR_trace = np.asarray(self.BAR_trace)
-    #     if USE_BAR is True:
-    #         self.BF_BAR = self.compute_BAR()
-    #         print("BAR Bayes factor estimates")
-    #         print(self.BF_BAR)
-    #
-    #     else:
-    #         self.BF_BAR = None
-    #
-    #     if plotting:
-    #
-    #         utils.create_param_triangle_plot_4D(
-    #             self.trace_model_0,
-    #             "trace_model_0",
-    #             self.lit_params,
-    #             self.properties,
-    #             self.compound,
-    #             self.steps,
-    #         )
-    #         utils.create_param_triangle_plot_4D(
-    #             self.trace_model_1,
-    #             "trace_model_1",
-    #             self.lit_params,
-    #             self.properties,
-    #             self.compound,
-    #             self.steps,
-    #         )
-    #         utils.create_param_triangle_plot_4D(
-    #             self.trace_model_2,
-    #             "trace_model_2",
-    #             self.lit_params,
-    #             self.properties,
-    #             self.compound,
-    #             self.steps,
-    #         )
-    #
-    #         utils.create_percent_dev_triangle_plot(
-    #             percent_dev_trace_equil,
-    #             "percent_dev_trace",
-    #             self.lit_devs,
-    #             self.prob,
-    #             self.properties,
-    #             self.compound,
-    #             self.steps,
-    #         )
-    #
-    #     return (
-    #         self.trace_tuned,
-    #         self.logp_trace_tuned,
-    #         self.percent_dev_trace_tuned,
-    #         self.BAR_trace,
-    #     )
 
 
 class BiasedRJMCSimulation(RJMCSimulation):

--- a/bayesiantesting/kernels/samplers/__init__.py
+++ b/bayesiantesting/kernels/samplers/__init__.py
@@ -1,3 +1,5 @@
 from .hmc import NUTS, Hamiltonian
+from .mcmc import MetropolisSampler
+from .samplers import Sampler
 
-__all__ = [Hamiltonian, NUTS]
+__all__ = [Hamiltonian, MetropolisSampler, NUTS, Sampler]

--- a/bayesiantesting/kernels/samplers/hmc.py
+++ b/bayesiantesting/kernels/samplers/hmc.py
@@ -14,78 +14,92 @@ made flake8 compliant, and had docstrings converted to Numpy style.
 :license: MIT, see LICENSE for more details.
 """
 import autograd
-import autograd.numpy as np
+import numpy
+import torch
+
+from bayesiantesting.kernels.samplers import Sampler
 
 
-class Hamiltonian:
+class Hamiltonian(Sampler):
     """Hamiltonian MCMC sampler."""
 
-    def __init__(self, log_p, n_parameters, step_size=1, n_steps=5):
-        """Initializes self.
-
+    def __init__(self, log_p_function, model_collection, step_size=1.0, n_steps=5):
+        """
         Parameters
         ----------
-        log_p: function
-            The log probability function to sample.
-        n_parameters: int
-            The number of parameters to sample over.
         step_size: float
             The step size for the deterministic proposals.
         n_steps: int
             The number of leapfrog steps to take per step.
         """
 
-        self._step_size = step_size / n_parameters ** (1 / 4)
+        super().__init__(log_p_function, model_collection)
+
+        if model_collection.n_models > 1:
+            raise NotImplementedError()
+
+        self._step_size = numpy.ones(model_collection.n_models) * step_size
+
+        for index, model in enumerate(model_collection.models):
+            self._step_size[index] /= model.n_trainable_parameters ** (1 / 4)
+
         self._n_steps = n_steps
 
-        self._scale = np.ones(n_parameters)
-
-        self._log_p = log_p
-        self._gradient = autograd.grad(log_p)
+    @staticmethod
+    def _energy(log_p, momentum):
+        return log_p - 0.5 * numpy.dot(momentum, momentum)
 
     @staticmethod
-    def leapfrog(x, r, step_size, grad):
+    def _leapfrog(parameters, model_index, momentum, gradient_function, step_size):
 
-        r1 = r + step_size / 2 * grad(x)
-        x1 = x + step_size * r1
-        r2 = r1 + step_size / 2 * grad(x1)
+        r1 = momentum + step_size / 2 * gradient_function(parameters, model_index)
+        x1 = parameters + step_size * r1
+        r2 = r1 + step_size / 2 * gradient_function(x1, model_index)
 
         return x1, r2
 
-    @staticmethod
-    def accept(x, y, r_0, r, log_p):
+    def _initial_momentum(self, model_index):
+        model = self._model_collection[model_index]
+        return torch.randn(model.n_trainable_parameters).item()
 
-        energy_new = Hamiltonian.energy(log_p, y, r)
-        energy = Hamiltonian.energy(log_p, x, r_0)
-        criteria = np.min(np.array([0, energy_new - energy]))
+    def step(self, parameters, model_index, log_p, adapt=False):
 
-        return np.log(np.random.rand()) < criteria
+        initial_momentum = self._initial_momentum(model_index)
+        proposed_parameters, proposed_momentum = parameters, initial_momentum
 
-    @staticmethod
-    def energy(log_p, x, r):
-        return log_p(x) - 0.5 * np.dot(r, r)
-
-    @staticmethod
-    def initial_momentum(scale):
-        return np.random.normal(0, scale)
-
-    def step(self, parameters, adapt=False):
-
-        x = parameters
-        r0 = self.initial_momentum(self._scale)
-        y, r = x, r0
-
+        # Propose the new parameters.
         for i in range(self._n_steps):
-            y, r = Hamiltonian.leapfrog(y, r, self._step_size, self._gradient)
 
-        accepted = False
+            proposed_parameters, proposed_momentum = self._leapfrog(
+                parameters=proposed_parameters,
+                model_index=model_index,
+                momentum=proposed_momentum,
+                gradient_function=self._gradient_function,
+                step_size=self._step_size[model_index],
+            )
 
-        if Hamiltonian.accept(x, y, r0, r, self._log_p):
+        proposed_log_p = self._log_p_function(proposed_parameters, model_index)
 
-            x = y
-            accepted = True
+        # Decide whether to accept the move or not.
+        energy_new = self._energy(proposed_log_p, proposed_momentum)
+        energy = self._energy(log_p, initial_momentum)
 
-        return x, accepted
+        criteria = numpy.min(numpy.array([0, energy_new - energy]))
+
+        random_number = numpy.log(torch.rand((1,)).item())
+        accept = random_number < criteria
+
+        # Update the bookkeeping
+        self._proposed_moves[model_index] += 1
+
+        if accept:
+
+            self._accepted_moves[model_index] += 1
+
+            parameters = proposed_parameters
+            log_p = proposed_log_p
+
+        return parameters, log_p, accept
 
 
 class NUTS(Hamiltonian):
@@ -98,8 +112,8 @@ class NUTS(Hamiltonian):
 
     def __init__(
         self,
-        log_p,
-        n_parameters,
+        log_p_function,
+        model_collection,
         step_size=0.01,
         energy_max=1000.0,
         target_accept=0.65,
@@ -108,7 +122,6 @@ class NUTS(Hamiltonian):
         t0=10.0,
     ):
         """
-
         Parameters
         ----------
         step_size: float
@@ -118,14 +131,15 @@ class NUTS(Hamiltonian):
             Maximum energy.
         target_accept: float
             Target acceptance rate.
-        gamma
+        gamma: float
+            The value of gamma.
         k: float
             Scales the speed of step size adaptation.
         t0: float
             Slows initial step size adaptation.
         """
 
-        super(NUTS, self).__init__(log_p, n_parameters, step_size, -1)
+        super().__init__(log_p_function, model_collection, step_size, -1)
 
         self._energy_max = energy_max
 
@@ -136,7 +150,7 @@ class NUTS(Hamiltonian):
 
         self._h_bar = 0.0
         self._e_bar = 1.0
-        self._mu = np.log(self._step_size * 10)
+        self._mu = numpy.log(self._step_size * 10)
 
         self._sampled = 0
 
@@ -146,59 +160,58 @@ class NUTS(Hamiltonian):
     def find_reasonable_epsilon(parameters, log_p_function):
         """Heuristic for choosing an initial value of epsilon
         (Algorithm 4)."""
+
         gradient_function = autograd.grad(log_p_function)
 
         x, x0 = parameters, parameters
 
         e0 = 1.0
-        r0 = np.random.normal(0.0, 1.0, len(x))
+        r0 = torch.randn(len(x)).item()
 
-        x1, r1 = Hamiltonian.leapfrog(x0, r0, e0, gradient_function)
+        x1, r1 = Hamiltonian._leapfrog(x0, 0, r0, gradient_function, e0)
 
         log_p_0 = log_p_function(x1)
-        log_p_gradient_0 = gradient_function(x1)
+        log_p_gradient_0 = gradient_function(x1, 0)
 
         log_p = log_p_0
         log_p_gradient = log_p_gradient_0
 
         # Get into a regime where things are finite / not NaN using the
-        while np.isinf(log_p) or any(np.isinf(log_p_gradient)):
+        while numpy.isinf(log_p) or any(numpy.isinf(log_p_gradient)):
 
             e0 *= 0.5
 
-            x1, r1 = Hamiltonian.leapfrog(x0, r0, e0, gradient_function)
+            x1, r1 = Hamiltonian._leapfrog(x0, 0, r0, gradient_function, e0)
 
             log_p = log_p_function(x1)
-            log_p_gradient = gradient_function(x1)
+            log_p_gradient = gradient_function(x1, 0)
 
-        log_alpha = log_p - log_p_0 - 0.5 * (np.dot(r1, r1) - np.dot(r0, r0))
+        log_alpha = log_p - log_p_0 - 0.5 * (numpy.dot(r1, r1) - numpy.dot(r0, r0))
 
-        accept = 1.0 if log_alpha > np.log(0.5) else -1.0
+        accept = 1.0 if log_alpha > numpy.log(0.5) else -1.0
 
-        while accept * log_alpha > -accept * np.log(2):
+        while accept * log_alpha > -accept * numpy.log(2):
 
             e0 = e0 * (2.0 ** accept)
 
-            x1, r1 = Hamiltonian.leapfrog(x0, r0, e0, gradient_function)
+            x1, r1 = Hamiltonian._leapfrog(x0, 0, r0, gradient_function, e0)
 
             log_p = log_p_function(x1)
-
-            log_alpha = log_p - log_p_0 - 0.5 * (np.dot(r1, r1) - np.dot(r0, r0))
+            log_alpha = log_p - log_p_0 - 0.5 * (numpy.dot(r1, r1) - numpy.dot(r0, r0))
 
         return e0
 
-    def step(self, parameters, adapt=False):
+    @staticmethod
+    def bern(p):
+        return torch.rand((1,)).item() < p
 
-        if adapt:
-            self._has_adapted = True
-        elif not self._has_adapted:
-            raise ValueError("This sampler must be adaptively stepped at least once.")
+    def step(self, parameters, model_index, log_p, adapt=False):
 
         x = parameters
-        r0 = self.initial_momentum(self._scale)
+        r0 = self._initial_momentum(model_index)
 
-        u = np.random.uniform()
-        e = self._step_size
+        u = torch.rand((1,)).item()
+        e = self._step_size[model_index]
 
         xn, xp, rn, rp, y = x, x, r0, r0, x
         j, n, s = 0, 1, 1
@@ -210,45 +223,25 @@ class NUTS(Hamiltonian):
             v = self.bern(0.5) * 2 - 1
 
             if v == -1:
-                xn, rn, _, _, x1, n1, s1, a, na = self.build_tree(
-                    xn,
-                    rn,
-                    u,
-                    v,
-                    j,
-                    e,
-                    x,
-                    r0,
-                    self._log_p,
-                    self._gradient,
-                    self._energy_max,
+                xn, rn, _, _, x1, n1, s1, a, na = self._build_tree(
+                    xn, model_index, rn, u, v, j, e, x, r0,
                 )
             else:
-                _, _, xp, rp, x1, n1, s1, a, na = self.build_tree(
-                    xp,
-                    rp,
-                    u,
-                    v,
-                    j,
-                    e,
-                    x,
-                    r0,
-                    self._log_p,
-                    self._gradient,
-                    self._energy_max,
+                _, _, xp, rp, x1, n1, s1, a, na = self._build_tree(
+                    xp, model_index, rp, u, v, j, e, x, r0,
                 )
 
-            if s1 == 1 and self.bern(np.min(np.array([1, n1 / n]))):
+            if s1 == 1 and self.bern(numpy.min(numpy.array([1, n1 / n]))):
                 y = x1
 
             dx = xp - xn
-            s = s1 * (np.dot(dx, rn) >= 0) * (np.dot(dx, rp) >= 0)
+            s = s1 * (numpy.dot(dx, rn) >= 0) * (numpy.dot(dx, rp) >= 0)
             n = n + n1
             j = j + 1
 
         if not adapt:
 
-            self._step_size = self._e_bar
+            self._step_size[model_index] = self._e_bar
 
         else:
 
@@ -258,29 +251,29 @@ class NUTS(Hamiltonian):
 
             self._h_bar = (1 - w) * self._h_bar + w * (self._target_accept - a / na)
             log_e = self._mu - (m ** 0.5 / self._gamma) * self._h_bar
-            self._step_size = np.exp(log_e)
+            self._step_size = numpy.exp(log_e)
             z = m ** (-self._k)
-            self._e_bar = np.exp(z * log_e + (1 - z) * np.log(self._e_bar))
+            self._e_bar = numpy.exp(z * log_e + (1 - z) * numpy.log(self._e_bar))
 
-        print(y)
-        return y, True
+        # Update the bookkeeping
+        self._proposed_moves[model_index] += 1
+        self._accepted_moves[model_index] += 1
 
-    @staticmethod
-    def bern(p):
-        return np.random.uniform() < p
+        proposed_log_p = self._log_p_function(y, model_index)
 
-    @staticmethod
-    def build_tree(x, r, u, v, j, e, x0, r0, log_p, log_p_gradient, energy_max):
+        return y, proposed_log_p, True
+
+    def _build_tree(self, x, model_index, r, u, v, j, e, x0, r0):
 
         if j == 0:
             # Base case — take one leapfrog step in the direction v
-            x1, r1 = Hamiltonian.leapfrog(x, r, v * e, log_p_gradient)
-            energy = Hamiltonian.energy(log_p, x1, r1)
-            energy_0 = Hamiltonian.energy(log_p, x0, r0)
+            x1, r1 = self._leapfrog(x, model_index, r, self._gradient_function, v * e)
+            energy = self._energy(x1, r1)
+            energy_0 = self._energy(x0, r0)
             delta_energy = energy - energy_0
 
-            n1 = np.log(u) - delta_energy <= 0
-            s1 = np.log(u) - delta_energy < energy_max
+            n1 = numpy.log(u) - delta_energy <= 0
+            s1 = numpy.log(u) - delta_energy < self._energy_max
 
             return (
                 x1,
@@ -290,42 +283,22 @@ class NUTS(Hamiltonian):
                 x1,
                 n1,
                 s1,
-                np.min(np.array([1, np.exp(delta_energy)])),
+                numpy.min(numpy.array([1, numpy.exp(delta_energy)])),
                 1,
             )
         else:
             # Recursion — implicitly build the left and right subtrees
-            xn, rn, xp, rp, x1, n1, s1, a1, na1 = NUTS.build_tree(
-                x, r, u, v, j - 1, e, x0, r0, log_p, log_p_gradient, energy_max
+            xn, rn, xp, rp, x1, n1, s1, a1, na1 = self._build_tree(
+                x, model_index, r, u, v, j - 1, e, x0, r0
             )
             if s1 == 1:
                 if v == -1:
-                    xn, rn, _, _, x2, n2, s2, a2, na2 = NUTS.build_tree(
-                        xn,
-                        rn,
-                        u,
-                        v,
-                        j - 1,
-                        e,
-                        x0,
-                        r0,
-                        log_p,
-                        log_p_gradient,
-                        energy_max,
+                    xn, rn, _, _, x2, n2, s2, a2, na2 = self._build_tree(
+                        xn, model_index, rn, u, v, j - 1, e, x0, r0,
                     )
                 else:
-                    _, _, xp, rp, x2, n2, s2, a2, na2 = NUTS.build_tree(
-                        xp,
-                        rp,
-                        u,
-                        v,
-                        j - 1,
-                        e,
-                        x0,
-                        r0,
-                        log_p,
-                        log_p_gradient,
-                        energy_max,
+                    _, _, xp, rp, x2, n2, s2, a2, na2 = self._build_tree(
+                        xp, model_index, rp, u, v, j - 1, e, x0, r0,
                     )
                 if NUTS.bern(n2 / max(n1 + n2, 1.0)):
                     x1 = x2
@@ -334,6 +307,6 @@ class NUTS(Hamiltonian):
                 na1 = na1 + na2
 
                 dx = xp - xn
-                s1 = s2 * (np.dot(dx, rn) >= 0) * (np.dot(dx, rp) >= 0)
+                s1 = s2 * (numpy.dot(dx, rn) >= 0) * (numpy.dot(dx, rp) >= 0)
                 n1 = n1 + n2
             return xn, rn, xp, rp, x1, n1, s1, a1, na1

--- a/bayesiantesting/kernels/samplers/hmc.py
+++ b/bayesiantesting/kernels/samplers/hmc.py
@@ -305,3 +305,12 @@ class NUTS(Hamiltonian):
                 s1 = s2 * (numpy.dot(dx, rn) >= 0) * (numpy.dot(dx, rp) >= 0)
                 n1 = n1 + n2
             return xn, rn, xp, rp, x1, n1, s1, a1, na1
+
+    def get_statistics_dictionary(self):
+
+        return_value = super(NUTS, self).get_statistics_dictionary()
+        return_value.update(
+            {"step_size": self._step_size,}
+        )
+
+        return return_value

--- a/bayesiantesting/kernels/samplers/hmc.py
+++ b/bayesiantesting/kernels/samplers/hmc.py
@@ -309,8 +309,6 @@ class NUTS(Hamiltonian):
     def get_statistics_dictionary(self):
 
         return_value = super(NUTS, self).get_statistics_dictionary()
-        return_value.update(
-            {"step_size": self._step_size,}
-        )
+        return_value.update({"step_size": self._step_size})
 
         return return_value

--- a/bayesiantesting/kernels/samplers/mcmc.py
+++ b/bayesiantesting/kernels/samplers/mcmc.py
@@ -23,10 +23,7 @@ class MetropolisSampler(Sampler):
     @proposal_sizes.setter
     def proposal_sizes(self, value):
 
-        assert value.shape == (
-            self._model_collection.n_models,
-            self._max_n_parameters,
-        )
+        assert value.shape == (self._model_collection.n_models, self._max_n_parameters,)
         self._proposal_sizes = value
 
     def __init__(

--- a/bayesiantesting/kernels/samplers/mcmc.py
+++ b/bayesiantesting/kernels/samplers/mcmc.py
@@ -79,11 +79,11 @@ class MetropolisSampler(Sampler):
         accept = random_number < alpha
 
         # Update the bookkeeping
-        self._proposed_moves[parameter_index] += 1
+        self._proposed_moves[model_index][parameter_index] += 1
 
         if accept:
 
-            self._accepted_moves[parameter_index] += 1
+            self._accepted_moves[model_index][parameter_index] += 1
 
             parameters = proposed_parameters
             log_p = proposed_log_p
@@ -121,3 +121,12 @@ class MetropolisSampler(Sampler):
                 self._proposal_sizes[index][parameter_index] *= scale
 
         self.reset_counters()
+
+    def get_statistics_dictionary(self):
+
+        return_value = super(MetropolisSampler, self).get_statistics_dictionary()
+        return_value.update(
+            {"proposal_sizes": self.proposal_sizes.tolist(),}
+        )
+
+        return return_value

--- a/bayesiantesting/kernels/samplers/mcmc.py
+++ b/bayesiantesting/kernels/samplers/mcmc.py
@@ -125,8 +125,6 @@ class MetropolisSampler(Sampler):
     def get_statistics_dictionary(self):
 
         return_value = super(MetropolisSampler, self).get_statistics_dictionary()
-        return_value.update(
-            {"proposal_sizes": self.proposal_sizes.tolist(),}
-        )
+        return_value.update({"proposal_sizes": self.proposal_sizes.tolist()})
 
         return return_value

--- a/bayesiantesting/kernels/samplers/mcmc.py
+++ b/bayesiantesting/kernels/samplers/mcmc.py
@@ -1,0 +1,120 @@
+"""
+This module implements a samplers based off of the
+Metropolis-Hasting acceptance criteria. These samplers
+do not require nor make use of gradient information.
+"""
+import numpy
+import torch
+
+from bayesiantesting.kernels.samplers.samplers import Sampler
+from bayesiantesting.utils import distributions
+
+
+class MetropolisSampler(Sampler):
+    """A base class for different in-model parameter samplers."""
+
+    @property
+    def proposal_sizes(self):
+        """numpy.ndarray: The size of the proposals to make for each
+        parameter with shape=(n_models, n_parameters).
+        """
+        return self._proposal_sizes
+
+    @proposal_sizes.setter
+    def proposal_sizes(self, value):
+
+        assert value.shape == (
+            self._model_collection.n_models,
+            self._max_n_parameters,
+        )
+        self._proposal_sizes = value
+
+    def __init__(
+        self,
+        log_p_function,
+        model_collection,
+        proposal_sizes,
+        acceptance_target=0.5,
+        tune_frequency=100,
+    ):
+        """Initializes self.
+
+        Parameters
+        ----------
+        proposal_sizes: numpy.ndarray, optional
+            The size of the proposals to make for each parameter
+            with shape=(n_models, n_parameters).
+        acceptance_target: float
+            The target acceptance rate for this sampler
+        tune_frequency: int
+            The number of steps to take before attempting to
+            tune the parameters.
+        """
+        super().__init__(log_p_function, model_collection)
+
+        assert 0.0 < acceptance_target <= 1.0
+        self._acceptance_target = acceptance_target
+
+        self.proposal_sizes = proposal_sizes
+
+        self._tune_frequency = tune_frequency
+
+    def step(self, parameters, model_index, log_p, adapt=False):
+
+        model = self._model_collection[model_index]
+
+        # Choose a random parameter to change
+        parameter_index = torch.randint(model.n_trainable_parameters, (1,))
+
+        # Sample the new parameters from a normal distribution.
+        parameters[parameter_index] = distributions.Normal(
+            parameters[parameter_index],
+            self._proposal_sizes[model_index][parameter_index],
+        ).sample()
+
+        proposed_log_p = self._log_p_function(parameters, model_index)
+
+        alpha = proposed_log_p - log_p
+
+        random_number = numpy.log(torch.rand((1,)).item())
+        accept = random_number < alpha
+
+        # Update the bookkeeping
+        self._proposed_moves[parameter_index] += 1
+
+        if accept:
+
+            self._accepted_moves[parameter_index] += 1
+            log_p = proposed_log_p
+
+        # Tune the proposals if needed
+        total_proposed_moves = numpy.sum(self._proposed_moves)
+
+        if (
+            adapt
+            and self._tune_frequency > 0
+            and total_proposed_moves > 0
+            and total_proposed_moves % self._tune_frequency == 0
+        ):
+            self._tune_proposals()
+
+        return parameters, log_p, accept
+
+    def _tune_proposals(self):
+        """Attempt to tune the move proposals to reach the
+        `acceptance_target`.
+        """
+
+        for index, model in enumerate(self._model_collection.models):
+
+            divisor = numpy.maximum(1, self._proposed_moves[index])
+            acceptance_rates = self._accepted_moves[index] / divisor
+
+            for parameter_index, rate in enumerate(acceptance_rates):
+
+                scale = 0.9 if rate < self._acceptance_target else 1.1
+                scale = (
+                    1.0 if self._proposed_moves[index][parameter_index] == 0 else scale
+                )
+
+                self._proposal_sizes[index][parameter_index] *= scale

--- a/bayesiantesting/kernels/samplers/samplers.py
+++ b/bayesiantesting/kernels/samplers/samplers.py
@@ -60,10 +60,10 @@ class Sampler(abc.ABC):
         )
 
         self._proposed_moves = numpy.zeros(
-            self._model_collection.n_models, self._max_n_parameters
+            (self._model_collection.n_models, self._max_n_parameters)
         )
         self._accepted_moves = numpy.zeros(
-            self._model_collection.n_models, self._max_n_parameters
+            (self._model_collection.n_models, self._max_n_parameters)
         )
 
     def reset_counters(self):
@@ -71,14 +71,14 @@ class Sampler(abc.ABC):
         proposed and accepted moves.
         """
         self._proposed_moves = numpy.zeros(
-            self._model_collection.n_models, self._max_n_parameters
+            (self._model_collection.n_models, self._max_n_parameters)
         )
         self._accepted_moves = numpy.zeros(
-            self._model_collection.n_models, self._max_n_parameters
+            (self._model_collection.n_models, self._max_n_parameters)
         )
 
     @abc.abstractmethod
-    def step(self, parameters, model_index, log_p, adapt=False):
+    def step(self, parameters, model_index, log_p, adapt):
         """Propagates a set of parameters forward one step.
 
         Parameters

--- a/bayesiantesting/kernels/samplers/samplers.py
+++ b/bayesiantesting/kernels/samplers/samplers.py
@@ -103,3 +103,16 @@ class Sampler(abc.ABC):
             Whether this move was accepted or not.
         """
         raise NotImplementedError()
+
+    def get_statistics_dictionary(self):
+        """Returns a dictionary containing statistics
+        about this sampler.
+
+        Returns
+        -------
+        dict of str and Any
+        """
+        return {
+            "proposed_moves": self.proposed_moves.tolist(),
+            "accepted_moves": self.accepted_moves.tolist(),
+        }

--- a/bayesiantesting/kernels/samplers/samplers.py
+++ b/bayesiantesting/kernels/samplers/samplers.py
@@ -1,0 +1,105 @@
+import abc
+
+import autograd
+import numpy
+
+from bayesiantesting.models import ModelCollection
+
+
+class Sampler(abc.ABC):
+    """A base class for different in-model parameter samplers."""
+
+    @property
+    def log_p_function(self):
+        """function: The log p function to sample over.
+        """
+        return self._log_p_function
+
+    @log_p_function.setter
+    def log_p_function(self, value):
+
+        self._log_p_function = value
+        self._gradient_function = None if value is None else autograd.grad(value)
+
+    @property
+    def proposed_moves(self):
+        """numpy.ndarray: The number of moves this sampler has
+        proposed for each parameter with shape=(n_parameters).
+        """
+        return self._proposed_moves
+
+    @property
+    def accepted_moves(self):
+        """numpy.ndarray: The number of moves this sampler has
+        accepted for each parameter with shape=(n_parameters).
+        """
+        return self._accepted_moves
+
+    def __init__(self, log_p_function, model_collection):
+        """Initializes self.
+
+        Parameters
+        ----------
+        log_p_function: function, optional
+            The log probability function to sample.
+        model_collection: ModelCollection
+            The model whose parameters are being sampled.
+        """
+
+        assert isinstance(model_collection, ModelCollection)
+
+        self._log_p_function = None
+        self._gradient_function = None
+
+        self.log_p_function = log_p_function
+
+        self._model_collection = model_collection
+
+        self._max_n_parameters = max(
+            (model.n_trainable_parameters for model in model_collection.models)
+        )
+
+        self._proposed_moves = numpy.zeros(
+            self._model_collection.n_models, self._max_n_parameters
+        )
+        self._accepted_moves = numpy.zeros(
+            self._model_collection.n_models, self._max_n_parameters
+        )
+
+    def reset_counters(self):
+        """Resets this samplers count of the number of
+        proposed and accepted moves.
+        """
+        self._proposed_moves = numpy.zeros(
+            self._model_collection.n_models, self._max_n_parameters
+        )
+        self._accepted_moves = numpy.zeros(
+            self._model_collection.n_models, self._max_n_parameters
+        )
+
+    @abc.abstractmethod
+    def step(self, parameters, model_index, log_p, adapt=False):
+        """Propagates a set of parameters forward one step.
+
+        Parameters
+        ----------
+        parameters: numpy.ndarray
+            The parameters to propagate with shape=(n_params)
+        model_index: int
+            The index of the model to sample in.
+        log_p: float
+            The value of log p evaluated at the current `parameters`.
+        adapt: bool
+            If True, this sampler will attempt to tune it's
+            parameters for optimal sampling.
+
+        Returns
+        -------
+        numpy.ndarray
+            The new parameters.
+        float
+            The value of log p evaluated at the new parameters.
+        bool
+            Whether this move was accepted or not.
+        """
+        raise NotImplementedError()

--- a/studies/mcmc/basic_run.yaml
+++ b/studies/mcmc/basic_run.yaml
@@ -30,7 +30,7 @@ priors:
 properties: All
 save_traj: true
 simulation_type: Basic
-steps: 2000000
+steps: 1000000
 swap_freq: 0.1
 trange:
 - 0.55

--- a/studies/mcmc/run.py
+++ b/studies/mcmc/run.py
@@ -148,7 +148,7 @@ def main():
     # Run the simulation.
     simulation = MCMCSimulation(
         model_collection=model,
-        warm_up_steps=int(simulation_params["steps"] * 0.3),
+        warm_up_steps=int(simulation_params["steps"] * 0.1),
         steps=simulation_params["steps"],
         discard_warm_up_data=True,
     )

--- a/studies/samplers/run.py
+++ b/studies/samplers/run.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+
+import numpy
+
+from bayesiantesting.kernels import MCMCSimulation
+from bayesiantesting.kernels.samplers import NUTS, MetropolisSampler
+from bayesiantesting.models import Model, ModelCollection
+from bayesiantesting.utils import distributions
+
+
+class GaussianModel(Model):
+    """A representation of the two-center Lennard-Jones model, which
+    can be evaluated using a surrogate model against a `NISTDataSet`.
+    """
+
+    def __init__(self, name, prior_settings, loc, scale):
+
+        super().__init__(name, prior_settings, {})
+
+        self._loc = loc
+        self._scale = scale
+
+    def evaluate_log_likelihood(self, parameters):
+        return distributions.Normal(self._loc, self._scale).log_pdf(parameters)
+
+    def compute_percentage_deviations(self, parameters):
+        return {}
+
+
+def main():
+
+    # Build the model.
+    priors = {"uniform": ("uniform", numpy.array([-5.0, 5.0]))}
+    model = GaussianModel("gaussian", priors, 0.0, 1.0)
+
+    model_collection = ModelCollection("gaussian", [model])
+
+    # Draw the initial parameter values from the model priors.
+    initial_parameters = model.sample_priors()
+
+    # Run a simulation using a Metropolis sampler.
+    proposal_scales = numpy.array([initial_parameters / 100.0])
+
+    sampler = MetropolisSampler(None, model_collection, proposal_scales)
+
+    simulation = MCMCSimulation(
+        model_collection=model,
+        warm_up_steps=50000,
+        steps=50000,
+        discard_warm_up_data=True,
+        sampler=sampler,
+        output_directory_path="metropolis",
+    )
+
+    trace, log_p_trace, percent_deviation_trace = simulation.run(initial_parameters)
+    model.plot(trace, log_p_trace, percent_deviation_trace, show=True)
+
+    # Run a simulation using a NUTS sampler.
+    def log_p_function(parameters, _):
+        return model.evaluate_log_posterior(parameters)
+
+    step_size = 1.0  # NUTS.find_reasonable_epsilon(initial_parameters, log_p_function)
+    sampler = NUTS(None, model_collection, step_size)
+
+    simulation = MCMCSimulation(
+        model_collection=model,
+        warm_up_steps=5000,
+        steps=10000,
+        discard_warm_up_data=True,
+        sampler=sampler,
+        output_directory_path="nuts",
+    )
+
+    trace, log_p_trace, percent_deviation_trace = simulation.run(initial_parameters)
+    model.plot(trace, log_p_trace, percent_deviation_trace, show=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description
This PR aims to create a generic `Sampler` base class, extract the Metropolis sampling out of the MCMC kernel, and add studies to test each of the samplers.

## Status
- [x] Ready to go