### PR TITLE
Allow Integration Between Posterior and Reference Distributions

### DIFF
--- a/bayesiantesting/kernels/bayes.py
+++ b/bayesiantesting/kernels/bayes.py
@@ -35,7 +35,7 @@ class LambdaSimulation(MCMCSimulation):
         ln p(x|D, λ) = ln p(x) + λ ln p(D|x)
 
     where p(x) is the prior on x, and p(D|x) is the likelihood distribution
-    At λ=0.0 only the prior is sampled, at λ=1.0 the full prior is sampled.
+    At λ=0.0 only the prior is sampled, at λ=1.0 the full posterior is sampled.
 
     If a reference model q is set, the samples will be generated according
     to:

--- a/bayesiantesting/kernels/bayes.py
+++ b/bayesiantesting/kernels/bayes.py
@@ -22,8 +22,9 @@ from bayesiantesting.models import Model
 
 class LambdaSimulation(MCMCSimulation):
     """Builds an object that runs an MCMC simulation at a specific value of
-    lambda - a hyperparameter which interpolates between the prior and posterior
-    distributions.
+    lambda - a hyperparameter which interpolates between a target distribution
+    whose model evidence is intractable, and a reference distributions whose
+    evidence is.
 
     If no reference distribution is set, the samples will be generated from the
     following simple distribution:

--- a/bayesiantesting/kernels/bayes.py
+++ b/bayesiantesting/kernels/bayes.py
@@ -503,23 +503,24 @@ class BaseModelEvidenceKernel:
         pyplot.close(figure)
 
         # Plot d log p d lambda
-        figure, axes = pyplot.subplots(1, 1, figsize=(5, 5), dpi=200)
+        if self._requires_gradients:
+            figure, axes = pyplot.subplots(1, 1, figsize=(5, 5), dpi=200)
 
-        axes.errorbar(
-            self._lambda_values,
-            d_log_p_d_lambdas,
-            yerr=d_log_p_d_lambdas_std,
-            color="#17becf",
-        )
-        axes.set_xlabel(r"$\lambda$")
-        axes.set_ylabel(r"$\dfrac{\partial \ln{p}_{\lambda}}{\partial {\lambda}}$")
+            axes.errorbar(
+                self._lambda_values,
+                d_log_p_d_lambdas,
+                yerr=d_log_p_d_lambdas_std,
+                color="#17becf",
+            )
+            axes.set_xlabel(r"$\lambda$")
+            axes.set_ylabel(r"$\dfrac{\partial \ln{p}_{\lambda}}{\partial {\lambda}}$")
 
-        figure.savefig(
-            os.path.join(self._output_directory_path, f"d_log_p_d_lambdas.pdf")
-        )
-        pyplot.close(figure)
+            figure.savefig(
+                os.path.join(self._output_directory_path, f"d_log_p_d_lambdas.pdf")
+            )
+            pyplot.close(figure)
 
-        # Save the output as a json file and numpy files.
+        # Save the output as json files.
         results = self._get_results_dictionary(
             integral,
             standard_error,
@@ -533,15 +534,6 @@ class BaseModelEvidenceKernel:
             os.path.join(self._output_directory_path, "results.json"), "w"
         ) as file:
             json.dump(results, file, sort_keys=True, indent=4, separators=(",", ": "))
-
-        numpy.save(
-            os.path.join(self._output_directory_path, "d_log_p_d_lambdas.npy"),
-            d_log_p_d_lambdas,
-        )
-        numpy.save(
-            os.path.join(self._output_directory_path, "d_log_p_d_lambdas_std.npy"),
-            d_log_p_d_lambdas_std,
-        )
 
 
 class ThermodynamicIntegration(BaseModelEvidenceKernel):

--- a/bayesiantesting/kernels/bayes.py
+++ b/bayesiantesting/kernels/bayes.py
@@ -130,15 +130,22 @@ class LambdaSimulation(MCMCSimulation):
 
         else:
 
-            log_prior = lambda_value * model.evaluate_log_prior(parameters) + (
-                1.0 - lambda_value
-            ) * reference_model.evaluate_log_prior(parameters)
+            if numpy.isclose(lambda_value, 0.0):
 
-            log_likelihood = lambda_value * model.evaluate_log_likelihood(
-                parameters
-            ) + (1.0 - lambda_value) * reference_model.evaluate_log_likelihood(
-                parameters
-            )
+                log_prior = reference_model.evaluate_log_prior(parameters)
+                log_likelihood = reference_model.evaluate_log_likelihood(parameters)
+
+            else:
+
+                log_prior = lambda_value * model.evaluate_log_prior(parameters) + (
+                        1.0 - lambda_value
+                ) * reference_model.evaluate_log_prior(parameters)
+
+                log_likelihood = lambda_value * model.evaluate_log_likelihood(
+                    parameters
+                ) + (1.0 - lambda_value) * reference_model.evaluate_log_likelihood(
+                    parameters
+                )
 
         return log_prior + log_likelihood
 

--- a/bayesiantesting/kernels/bayes.py
+++ b/bayesiantesting/kernels/bayes.py
@@ -228,7 +228,7 @@ class BaseModelEvidenceKernel:
                 f"one value for each of the trainable model parameters."
             )
 
-    def run(self, initial_parameters, number_of_threads=1):
+    def run(self, initial_parameters, number_of_processes=1):
         """Run the simulation loop.
 
         Parameters
@@ -236,7 +236,7 @@ class BaseModelEvidenceKernel:
         initial_parameters: numpy.ndarray
             The initial parameters to use in the lambda
             simulations, with shape=(n_trainable_parameters).
-        number_of_threads: int
+        number_of_processes: int
             The number of processes to distribute the calculation
             across.
 
@@ -256,7 +256,7 @@ class BaseModelEvidenceKernel:
         self._validate_parameter_shapes(initial_parameters)
 
         # Simulate in each lambda window.
-        with Pool(number_of_threads) as pool:
+        with Pool(number_of_processes) as pool:
 
             run_with_args = functools.partial(
                 BaseModelEvidenceKernel._run_window,

--- a/bayesiantesting/models/continuous.py
+++ b/bayesiantesting/models/continuous.py
@@ -155,6 +155,54 @@ class TwoCenterLJModel(Model):
         return deviations
 
 
+class GaussianModel(Model):
+    """A toy model with a gaussian likelihood function with is
+    not conditioned on any data.
+    """
+
+    def __init__(self, name, prior_settings, loc, scale, weight=1.0):
+
+        super().__init__(name, prior_settings, {})
+
+        self._loc = loc
+        self._scale = scale
+
+        self._log_weight = numpy.log(weight)
+
+    def evaluate_log_likelihood(self, parameters):
+        return (
+            distributions.Normal(self._loc, self._scale).log_pdf(parameters)
+            + self._log_weight
+        )
+
+    def compute_percentage_deviations(self, parameters):
+        return {}
+
+
+class CauchyModel(Model):
+    """A toy model with a cauchy likelihood function with is
+    not conditioned on any data.
+    """
+
+    def __init__(self, name, prior_settings, loc, scale, weight=1.0):
+
+        super().__init__(name, prior_settings, {})
+
+        self._loc = loc
+        self._scale = scale
+
+        self._log_weight = numpy.log(weight)
+
+    def evaluate_log_likelihood(self, parameters):
+        return (
+            distributions.Cauchy(self._loc, self._scale).log_pdf(parameters)
+            + self._log_weight
+        )
+
+    def compute_percentage_deviations(self, parameters):
+        return {}
+
+
 class MultivariateGaussian(Model):
     """Represents an _unconditioned_ multivariate gaussian
     distribution.

--- a/bayesiantesting/models/models.py
+++ b/bayesiantesting/models/models.py
@@ -134,6 +134,10 @@ class Model:
 
             prior = distributions.Uniform(prior_values[0], prior_values[1])
 
+        elif prior_type == "none":
+
+            prior = None
+
         else:
             raise NotImplementedError()
 

--- a/bayesiantesting/models/models.py
+++ b/bayesiantesting/models/models.py
@@ -435,6 +435,13 @@ class Model:
             self.plot_percentage_deviations(percentage_deviations, show),
         )
 
+    def to_json(self):
+        raise NotImplementedError()
+
+    @classmethod
+    def from_json(cls, json_string):
+        raise NotImplementedError()
+
 
 class ModelCollection:
     """Represents a collection of models to simultaneously optimize.

--- a/bayesiantesting/tests/models/test_continuous.py
+++ b/bayesiantesting/tests/models/test_continuous.py
@@ -6,10 +6,11 @@ from random import random
 import autograd
 import numpy
 import pytest
+import torch.distributions
 
 from bayesiantesting.datasets.nist import NISTDataSet
 from bayesiantesting.models import Model
-from bayesiantesting.models.continuous import TwoCenterLJModel
+from bayesiantesting.models.continuous import TwoCenterLJModel, MultivariateGaussian
 from bayesiantesting.surrogates import StollWerthSurrogate
 
 
@@ -120,3 +121,28 @@ def test_evaluate_log_posterior(model):
 
     assert len(prior_gradients) == len(parameters)
     assert not numpy.allclose(prior_gradients, 0.0)
+
+
+def test_multivariate_normal():
+
+    mean_dictionary = {"epsilon": 1.0, "sigma": 5.0}
+    mean = numpy.array([*mean_dictionary.values()])
+
+    covariance = numpy.array([[1.0, 3.0 / 5.0], [3.0 / 5.0, 1.0]])
+
+    model = MultivariateGaussian("gaussian", mean_dictionary, covariance)
+
+    sample = model.sample_priors()
+    sample_tensor = torch.tensor(sample, requires_grad=True, dtype=torch.float64)
+
+    torch_mean = torch.tensor(mean, requires_grad=False, dtype=torch.float64)
+    torch_covariance = torch.tensor(
+        covariance, requires_grad=False, dtype=torch.float64
+    )
+
+    distribution = torch.distributions.MultivariateNormal(torch_mean, torch_covariance)
+
+    calculated_log_p = model.evaluate_log_prior(sample)
+    reference_log_p = distribution.log_prob(sample_tensor).item()
+
+    assert numpy.isclose(calculated_log_p, reference_log_p)

--- a/bayesiantesting/tests/models/test_continuous.py
+++ b/bayesiantesting/tests/models/test_continuous.py
@@ -10,7 +10,7 @@ import torch.distributions
 
 from bayesiantesting.datasets.nist import NISTDataSet
 from bayesiantesting.models import Model
-from bayesiantesting.models.continuous import TwoCenterLJModel, MultivariateGaussian
+from bayesiantesting.models.continuous import MultivariateGaussian, TwoCenterLJModel
 from bayesiantesting.surrogates import StollWerthSurrogate
 
 

--- a/bayesiantesting/tests/models/test_continuous.py
+++ b/bayesiantesting/tests/models/test_continuous.py
@@ -53,7 +53,7 @@ def test_evaluate_log_prior():
 
     counter = 0
 
-    while numpy.isinf(log_p) and counter < 1000:
+    while numpy.isinf(log_p) and counter < 10000:
 
         parameters = model.sample_priors()
         # Make sure the method call doesn't fail.
@@ -79,7 +79,7 @@ def test_evaluate_log_likelihood(model):
 
     counter = 0
 
-    while numpy.isinf(log_p) and counter < 1000:
+    while numpy.isinf(log_p) and counter < 10000:
 
         parameters = model.sample_priors()
         # Make sure the method call doesn't fail.
@@ -105,7 +105,7 @@ def test_evaluate_log_posterior(model):
 
     counter = 0
 
-    while numpy.isinf(log_p) and counter < 1000:
+    while numpy.isinf(log_p) and counter < 10000:
 
         parameters = model.sample_priors()
         # Make sure the method call doesn't fail.

--- a/studies/gaussian_fitting/run.py
+++ b/studies/gaussian_fitting/run.py
@@ -1,0 +1,79 @@
+import corner
+import numpy
+from matplotlib import pyplot
+
+from bayesiantesting.models.continuous import MultivariateGaussian
+from bayesiantesting.utils.distributions import HalfNormal, Normal
+
+
+def main():
+
+    for model_name in ["UA", "AUA", "AUA+Q"]:
+
+        trace = numpy.load(f"trace_{model_name}.npy")[::1000]
+
+        n_parameters = trace.shape[1] - 1
+
+        figure, axes = pyplot.subplots(1, n_parameters, figsize=(5, 5), dpi=200)
+
+        print(f"{model_name}\n\n")
+
+        for parameter_index in range(n_parameters):
+
+            if parameter_index < 3:
+
+                loc = numpy.mean(trace[:, parameter_index + 1])
+                scale = numpy.std(trace[:, parameter_index + 1]) * 1.10
+
+                distribution = Normal(loc, scale)
+                x = numpy.linspace(-5 * scale + loc, 5 * scale + loc, 100)
+
+                print(f"distributions.Normal({loc}, {scale})")
+
+            else:
+
+                scale = (
+                    numpy.sqrt(
+                        numpy.sum(trace[:, parameter_index + 1] ** 2)
+                        / len(trace[:, parameter_index + 1])
+                    )
+                    * 1.10
+                )
+
+                distribution = HalfNormal(scale)
+                x = numpy.linspace(0.0, 5 * scale, 100)
+
+                print(f"distributions.HalfNormal({scale})")
+
+            y = numpy.exp(distribution.log_pdf(x))
+
+            axes[parameter_index].hist(trace[:, parameter_index + 1], density=True)
+            axes[parameter_index].plot(x, y)
+
+        figure.show()
+
+        multivariate_mean = numpy.mean(trace[:, 1:], axis=0)
+        multivariate_covariance = numpy.cov(trace[:, 1:].T)
+
+        print(multivariate_mean, multivariate_covariance)
+
+        mean_dictionary = {
+            index: value for index, value in enumerate(multivariate_mean)
+        }
+
+        model = MultivariateGaussian(
+            "gaussian", mean_dictionary, multivariate_covariance
+        )
+
+        trace = numpy.zeros((100000, len(multivariate_mean)))
+
+        for i in range(len(trace)):
+            trace[i] = model.sample_priors()
+
+        figure = corner.corner(trace, color="#17becf",)
+
+        figure.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/studies/mbar/basic_run.yaml
+++ b/studies/mbar/basic_run.yaml
@@ -20,5 +20,5 @@ priors:
   - - 0
     - 1
 properties: All
-warm_up_steps: 1000
-steps: 1000
+warm_up_steps: 500000
+steps: 4000000

--- a/studies/mbar/basic_run.yaml
+++ b/studies/mbar/basic_run.yaml
@@ -1,0 +1,24 @@
+number_data_points: 10
+trange:
+- 0.55
+- 0.95
+priors:
+  epsilon:
+  - exponential
+  - - 0
+    - 400
+  sigma:
+  - exponential
+  - - 0
+    - 5
+  L:
+  - exponential
+  - - 0
+    - 3
+  Q:
+  - exponential
+  - - 0
+    - 1
+properties: All
+warm_up_steps: 1000
+steps: 1000

--- a/studies/mbar/gaussian.py
+++ b/studies/mbar/gaussian.py
@@ -19,15 +19,44 @@ class GaussianModel(Model):
     can be evaluated using a surrogate model against a `NISTDataSet`.
     """
 
-    def __init__(self, name, prior_settings, loc, scale):
+    def __init__(self, name, prior_settings, loc, scale, weight=1.0):
 
         super().__init__(name, prior_settings, {})
 
         self._loc = loc
         self._scale = scale
 
+        self._log_weight = numpy.log(weight)
+
     def evaluate_log_likelihood(self, parameters):
-        return distributions.Normal(self._loc, self._scale).log_pdf(parameters)
+        return (
+            distributions.Normal(self._loc, self._scale).log_pdf(parameters)
+            + self._log_weight
+        )
+
+    def compute_percentage_deviations(self, parameters):
+        return {}
+
+
+class CauchyModel(Model):
+    """A representation of the two-center Lennard-Jones model, which
+    can be evaluated using a surrogate model against a `NISTDataSet`.
+    """
+
+    def __init__(self, name, prior_settings, loc, scale, weight=1.0):
+
+        super().__init__(name, prior_settings, {})
+
+        self._loc = loc
+        self._scale = scale
+
+        self._log_weight = numpy.log(weight)
+
+    def evaluate_log_likelihood(self, parameters):
+        return (
+            distributions.Cauchy(self._loc, self._scale).log_pdf(parameters)
+            + self._log_weight
+        )
 
     def compute_percentage_deviations(self, parameters):
         return {}
@@ -38,28 +67,39 @@ def main():
     priors = {"uniform": ("uniform", numpy.array([-50.0, 50.0]))}
 
     # Build the model / models.
-    model = GaussianModel("gaussian", priors, 0.0, 1.0)
+    model_a = CauchyModel("cauchy", priors, 0.0, 0.5, 0.75)
+    model_b = GaussianModel("gaussian", priors, 0.0, 1.0)
 
     # Draw the initial parameter values from the model priors.
-    initial_parameters = model.sample_priors()
+    initial_parameters = numpy.array([0.5])
 
     # Set up log spaced lambda windows
     lambda_values = numpy.geomspace(1.0, 2.0, 20) - 1.0
 
     # Run the simulation
-
     simulation = MBARIntegration(
         lambda_values=lambda_values,
-        model=model,
+        model=model_a,
         warm_up_steps=100000,
         steps=1000000,
         discard_warm_up_data=True,
         output_directory_path="gaussian",
+        reference_model=model_b,
     )
 
     _, integral, error = simulation.run(initial_parameters, number_of_threads=20)
 
-    print(f"Final Integral:", integral, " +/- ", error)
+    print(
+        f"Final Integral:",
+        integral,
+        " +/- ",
+        error,
+        f" [{integral - error * 1.96}, {integral + error * 1.96}",
+    )
+
+    print("==============================")
+
+    print(f"Expected Integral:", numpy.log(0.75), " +/- ", error)
     print("==============================")
 
 

--- a/studies/mbar/gaussian.py
+++ b/studies/mbar/gaussian.py
@@ -37,7 +37,7 @@ def main():
         reference_model=model_b,
     )
 
-    _, integral, error = simulation.run(initial_parameters, number_of_threads=20)
+    _, integral, error = simulation.run(initial_parameters, number_of_processes=20)
 
     print(
         f"Final Integral:",

--- a/studies/mbar/gaussian.py
+++ b/studies/mbar/gaussian.py
@@ -8,58 +8,8 @@ Created on Thu Oct 31 14:42:37 2019
 
 import numpy
 
-# from bayesiantesting.kernels import MCMCSimulation
 from bayesiantesting.kernels.bayes import MBARIntegration
-from bayesiantesting.models import Model
-from bayesiantesting.utils import distributions
-
-
-class GaussianModel(Model):
-    """A representation of the two-center Lennard-Jones model, which
-    can be evaluated using a surrogate model against a `NISTDataSet`.
-    """
-
-    def __init__(self, name, prior_settings, loc, scale, weight=1.0):
-
-        super().__init__(name, prior_settings, {})
-
-        self._loc = loc
-        self._scale = scale
-
-        self._log_weight = numpy.log(weight)
-
-    def evaluate_log_likelihood(self, parameters):
-        return (
-            distributions.Normal(self._loc, self._scale).log_pdf(parameters)
-            + self._log_weight
-        )
-
-    def compute_percentage_deviations(self, parameters):
-        return {}
-
-
-class CauchyModel(Model):
-    """A representation of the two-center Lennard-Jones model, which
-    can be evaluated using a surrogate model against a `NISTDataSet`.
-    """
-
-    def __init__(self, name, prior_settings, loc, scale, weight=1.0):
-
-        super().__init__(name, prior_settings, {})
-
-        self._loc = loc
-        self._scale = scale
-
-        self._log_weight = numpy.log(weight)
-
-    def evaluate_log_likelihood(self, parameters):
-        return (
-            distributions.Cauchy(self._loc, self._scale).log_pdf(parameters)
-            + self._log_weight
-        )
-
-    def compute_percentage_deviations(self, parameters):
-        return {}
+from bayesiantesting.models.continuous import CauchyModel, GaussianModel
 
 
 def main():

--- a/studies/mbar/run.py
+++ b/studies/mbar/run.py
@@ -50,8 +50,8 @@ def fit_multivariate_to_trace(model, output_directory, use_existing=True):
     # Run a short MCMC simulation to get better initial parameters
     simulation = MCMCSimulation(
         model_collection=model,
-        warm_up_steps=1000,
-        steps=1000,
+        warm_up_steps=100000,
+        steps=1000000,
         discard_warm_up_data=True,
         output_directory_path=output_directory,
     )

--- a/studies/mbar/run.py
+++ b/studies/mbar/run.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3# from bayesiantesting.kernels import MCMCSimulation
+import argparse
+import functools
+import json
+import os
+from multiprocessing.pool import Pool
+
+import numpy
+
+from bayesiantesting.kernels import MCMCSimulation
+from bayesiantesting.kernels.bayes import MBARIntegration
+from bayesiantesting.models.continuous import MultivariateGaussian
+from studies.utilities import (
+    generate_initial_parameters,
+    get_2clj_model,
+    parse_input_yaml,
+    prepare_data,
+)
+
+
+def fit_multivariate_to_trace(model, output_directory, use_existing=True):
+    """Fits a multivariate gaussian distribution to the posterior
+    of the model as sampled by a short MCMC simulation.
+
+    Parameters
+    ----------
+    model: Model
+        The model to sample.
+    output_directory: str
+        The directory to store the working files in.
+    use_existing: bool
+        If True, any existing fits will be used rather than regenerating
+        new fits.
+
+    Returns
+    -------
+    MultivariateGaussian
+        The fitted multivariate gaussian model.
+    """
+
+    fit_path = os.path.join(output_directory, f"{model.name}_fit.json")
+
+    if use_existing and os.path.isfile(fit_path):
+
+        with open(fit_path) as file:
+            return MultivariateGaussian.from_json(file.read())
+
+    initial_parameters = generate_initial_parameters(model)
+
+    # Run a short MCMC simulation to get better initial parameters
+    simulation = MCMCSimulation(
+        model_collection=model,
+        warm_up_steps=1000,
+        steps=1000,
+        discard_warm_up_data=True,
+        output_directory_path=output_directory,
+    )
+
+    trace, _, _ = simulation.run(initial_parameters)
+
+    mean = numpy.mean(trace[:, 1:], axis=0)
+    covariance = numpy.cov(trace[:, 1:].T)
+
+    mean_dictionary = {
+        label: value for label, value in zip(model.trainable_parameter_labels, mean)
+    }
+
+    fitted_distribution = MultivariateGaussian("gaussian", mean_dictionary, covariance)
+
+    with open(fit_path, "w") as file:
+        file.write(fitted_distribution.to_json())
+
+    return fitted_distribution
+
+
+def main(compound, n_processes):
+
+    simulation_params = parse_input_yaml("basic_run.yaml")
+
+    # Load the data.
+    data_set, property_types = prepare_data(simulation_params, compound)
+
+    # Build the models.
+    models = [
+        get_2clj_model(model_name, data_set, property_types, simulation_params)
+        for model_name in ["UA", "AUA", "AUA+Q"]
+    ]
+
+    # Fit multivariate normal distributions to this models posterior.
+    # This will be used as the analytical reference distribution.
+    fitting_directory = os.path.join(compound, "fitting")
+    os.makedirs(fitting_directory, exist_ok=True)
+
+    with Pool(n_processes) as pool:
+        reference_fits = pool.map(
+            functools.partial(
+                fit_multivariate_to_trace, output_directory=fitting_directory
+            ),
+            models,
+        )
+
+    # Run the MBAR calculations
+    results = {}
+
+    for model, reference_model in zip(models, reference_fits):
+
+        # Run the MBAR simulation
+        lambda_values = numpy.geomspace(1.0, 2.0, 16) - 1.0
+
+        output_directory = os.path.join(compound, f"mbar_{model.name}")
+
+        simulation = MBARIntegration(
+            lambda_values=lambda_values,
+            model=model,
+            warm_up_steps=simulation_params["warm_up_steps"],
+            steps=simulation_params["steps"],
+            discard_warm_up_data=True,
+            output_directory_path=output_directory,
+            reference_model=reference_model,
+        )
+
+        _, integral, error = simulation.run(
+            reference_model.mean, number_of_processes=n_processes
+        )
+
+        results[model.name] = {"integral": integral, "error": error}
+
+    with open(f"mbar_{compound}_results.json", "w") as file:
+        json.dump(results, file, sort_keys=True, indent=4, separators=(",", ": "))
+
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(
+        description="Perform an MBAR model evidence calculation.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+
+    parser.add_argument(
+        "--compound",
+        "-c",
+        type=str,
+        help="The compound to compute the model evidences for.",
+        required=True,
+    )
+
+    parser.add_argument(
+        "--processes",
+        "-nproc",
+        type=int,
+        help="The number processes to run the calculation across.",
+        required=False,
+        default=1,
+    )
+
+    args = parser.parse_args()
+
+    main(args.compound, args.processes)

--- a/studies/mcmc/run.py
+++ b/studies/mcmc/run.py
@@ -1,139 +1,15 @@
 #!/usr/bin/env python3
-import math
 
 import numpy
-import yaml
 
-from bayesiantesting import unit
-from bayesiantesting.datasets.nist import NISTDataSet, NISTDataType
 from bayesiantesting.kernels import MCMCSimulation
-from bayesiantesting.models.continuous import TwoCenterLJModel
-from bayesiantesting.surrogates import StollWerthSurrogate
-
-
-def parse_input_yaml(filepath):
-
-    print("Loading simulation params from " + filepath + "...")
-
-    with open(filepath) as file:
-        simulation_params = yaml.load(file, Loader=yaml.SafeLoader)
-
-    return simulation_params
-
-
-def prepare_data(simulation_params):
-    """From input parameters, pull appropriate experimental data and
-    uncertainty information.
-    """
-
-    # Retrieve the constants and thermophysical data
-    data_set = NISTDataSet(simulation_params["compound"])
-
-    # Filter the data to selected conditions.
-    minimum_temperature = (
-        simulation_params["trange"][0]
-        * data_set.critical_temperature.value.to(unit.kelvin).magnitude
-    )
-    maximum_temperature = (
-        simulation_params["trange"][1]
-        * data_set.critical_temperature.value.to(unit.kelvin).magnitude
-    )
-
-    data_set.filter(
-        minimum_temperature * unit.kelvin,
-        maximum_temperature * unit.kelvin,
-        simulation_params["number_data_points"],
-    )
-
-    property_types = []
-
-    if simulation_params["properties"] == "All":
-        property_types.extend(data_set.data_types)
-    else:
-        if "rhol" in simulation_params["properties"]:
-            property_types.append(NISTDataType.LiquidDensity)
-        if "Psat" in simulation_params["properties"]:
-            property_types.append(NISTDataType.SaturationPressure)
-
-    return data_set, property_types
-
-
-def get_model(model_name, data_set, property_types, simulation_params):
-
-    priors = {
-        "epsilon": simulation_params["priors"]["epsilon"],
-        "sigma": simulation_params["priors"]["sigma"],
-    }
-    fixed = {}
-
-    if model_name == "AUA":
-
-        priors["L"] = simulation_params["priors"]["L"]
-        fixed["Q"] = 0.0
-
-    elif model_name == "AUA+Q":
-
-        priors["L"] = simulation_params["priors"]["L"]
-        priors["Q"] = simulation_params["priors"]["Q"]
-
-    elif model_name == "UA":
-
-        fixed["L"] = data_set.bond_length.to(unit.nanometer).magnitude
-        fixed["Q"] = 0.0
-
-    else:
-
-        raise NotImplementedError()
-
-    model = TwoCenterLJModel(
-        model_name,
-        priors,
-        fixed,
-        data_set,
-        property_types,
-        StollWerthSurrogate(data_set.molecular_weight),
-    )
-
-    return model
-
-
-def generate_initial_parameters(model, attempts=5):
-
-    initial_log_p = -math.inf
-    initial_parameters = None
-
-    counter = 0
-
-    while counter < attempts:
-
-        parameters = model.sample_priors()
-        parameters = model.find_maximum_a_posteriori(parameters)
-
-        log_p = model.evaluate_log_posterior(parameters)
-        counter += 1
-
-        if math.isnan(log_p) or log_p < initial_log_p:
-            continue
-
-        initial_parameters = parameters
-        initial_log_p = log_p
-
-    if numpy.isnan(initial_log_p):
-
-        raise ValueError(
-            "The initial values could not be set without yielding "
-            "a NaN log posterior"
-        )
-
-    return initial_parameters
+from studies.utilities import get_2clj_model, parse_input_yaml, prepare_data
 
 
 def main():
 
     print("Parsing simulation params")
     simulation_params = parse_input_yaml("basic_run.yaml")
-
-    print(simulation_params["priors"])
 
     # Load the data.
     data_set, property_types = prepare_data(simulation_params)
@@ -149,7 +25,7 @@ def main():
     # Build the model / models.
     for model_name in ["AUA+Q"]:
 
-        model = get_model(model_name, data_set, property_types, simulation_params)
+        model = get_2clj_model(model_name, data_set, property_types, simulation_params)
 
         # Run the simulation.
         simulation = MCMCSimulation(
@@ -163,8 +39,6 @@ def main():
             initial_parameters[model.name]
         )
         model.plot(trace, log_p_trace, percent_deviation_trace, show=True)
-
-    print("Finished!")
 
 
 if __name__ == "__main__":

--- a/studies/rjmc/basic_run.yaml
+++ b/studies/rjmc/basic_run.yaml
@@ -1,8 +1,8 @@
 USE_BAR: false
 biasing_factor:
-- 297.65351362396
-- 300.0588385158948
-- 277.9084506552015
+- 4.8648
+- 8.0046
+- 0.0
 compound: C2H6
 number_data_points: 10
 priors:
@@ -25,7 +25,7 @@ priors:
 properties: All
 save_traj: true
 simulation_type: Basic
-steps: 100000
+steps: 4000000
 swap_freq: 0.5
 trange:
 - 0.55

--- a/studies/rjmc/gaussian.py
+++ b/studies/rjmc/gaussian.py
@@ -2,30 +2,8 @@ import numpy
 import torch
 
 from bayesiantesting.kernels.rjmc import BiasedRJMCSimulation
-from bayesiantesting.models import Model, ModelCollection
-from bayesiantesting.utils import distributions
-
-
-class GaussianModel(Model):
-    """A representation of the two-center Lennard-Jones model, which
-    can be evaluated using a surrogate model against a `NISTDataSet`.
-    """
-
-    def __init__(self, name, prior_settings, loc, scale, weight=1.0):
-
-        super().__init__(name, prior_settings, {})
-
-        self._loc = loc
-        self._scale = scale
-        self._weight = weight
-
-    def evaluate_log_likelihood(self, parameters):
-        return numpy.log(self._weight) + distributions.Normal(
-            self._loc, self._scale
-        ).log_pdf(parameters)
-
-    def compute_percentage_deviations(self, parameters):
-        return {}
+from bayesiantesting.models import ModelCollection
+from bayesiantesting.models.continuous import GaussianModel
 
 
 def main():

--- a/studies/rjmc/run.py
+++ b/studies/rjmc/run.py
@@ -6,128 +6,12 @@ Created on Thu Oct 31 14:42:37 2019
 @author: owenmadin
 """
 
-import math
-
 import numpy
-import yaml
 
-from bayesiantesting import unit
-from bayesiantesting.datasets.nist import NISTDataSet, NISTDataType
 from bayesiantesting.kernels.rjmc import BiasedRJMCSimulation
-from bayesiantesting.models.continuous import TwoCenterLJModel
 from bayesiantesting.models.discrete import TwoCenterLJModelCollection
-from bayesiantesting.surrogates import StollWerthSurrogate
 from bayesiantesting.utils import distributions
-
-
-def parse_input_yaml(filepath):
-
-    print("Loading simulation params from " + filepath + "...")
-
-    with open(filepath) as file:
-        simulation_params = yaml.load(file, Loader=yaml.SafeLoader)
-
-    return simulation_params
-
-
-def prepare_data(simulation_params):
-    """From input parameters, pull appropriate experimental data and
-    uncertainty information.
-    """
-
-    # Retrieve the constants and thermophysical data
-    data_set = NISTDataSet(simulation_params["compound"])
-
-    # Filter the data to selected conditions.
-    minimum_temperature = (
-        simulation_params["trange"][0]
-        * data_set.critical_temperature.value.to(unit.kelvin).magnitude
-    )
-    maximum_temperature = (
-        simulation_params["trange"][1]
-        * data_set.critical_temperature.value.to(unit.kelvin).magnitude
-    )
-
-    data_set.filter(
-        minimum_temperature * unit.kelvin,
-        maximum_temperature * unit.kelvin,
-        simulation_params["number_data_points"],
-    )
-
-    property_types = []
-
-    if simulation_params["properties"] == "All":
-        property_types.extend(data_set.data_types)
-    else:
-        if "rhol" in simulation_params["properties"]:
-            property_types.append(NISTDataType.LiquidDensity)
-        if "Psat" in simulation_params["properties"]:
-            property_types.append(NISTDataType.SaturationPressure)
-
-    return data_set, property_types
-
-
-def get_model(model_name, data_set, property_types, simulation_params):
-
-    priors = {
-        "epsilon": simulation_params["priors"]["epsilon"],
-        "sigma": simulation_params["priors"]["sigma"],
-    }
-    fixed = {}
-
-    if model_name == "AUA":
-
-        priors["L"] = simulation_params["priors"]["L"]
-        fixed["Q"] = 0.0
-
-    elif model_name == "AUA+Q":
-
-        priors["L"] = simulation_params["priors"]["L"]
-        priors["Q"] = simulation_params["priors"]["Q"]
-
-    elif model_name == "UA":
-
-        fixed["L"] = data_set.bond_length.to(unit.nanometer).magnitude
-        fixed["Q"] = 0.0
-
-    else:
-
-        raise NotImplementedError()
-
-    model = TwoCenterLJModel(
-        model_name,
-        priors,
-        fixed,
-        data_set,
-        property_types,
-        StollWerthSurrogate(data_set.molecular_weight),
-    )
-
-    return model
-
-
-def generate_initial_parameters(model):
-
-    initial_log_p = math.nan
-    initial_parameters = None
-
-    counter = 0
-
-    while math.isnan(initial_log_p) and counter < 1000:
-
-        initial_parameters = model.sample_priors()
-        initial_log_p = model.evaluate_log_posterior(initial_parameters)
-
-        counter += 1
-
-    if numpy.isnan(initial_log_p):
-
-        raise ValueError(
-            "The initial values could not be set without yielding "
-            "a NaN log posterior"
-        )
-
-    return initial_parameters
+from studies.utilities import get_2clj_model, parse_input_yaml, prepare_data
 
 
 def main():
@@ -140,9 +24,9 @@ def main():
 
     # Define the initial parameters as pre-computed MAP values,
     maximum_a_posteriori = [
-        numpy.array([97.0, 0.37850, 0.15]),
-        numpy.array([98.0, 0.37800, 0.15, 0.01]),
-        numpy.array([99.5, 0.37685]),
+        numpy.array([97.08159, 0.37892, 0.14780]),
+        numpy.array([97.29539, 0.37873, 0.14832, 0.01]),
+        numpy.array([99.50692, 0.37684]),
     ]
 
     # Define the mapping distributions
@@ -166,10 +50,13 @@ def main():
 
     # Build the model / models.
     sub_models = [
-        get_model("AUA", data_set, property_types, simulation_params),
-        get_model("AUA+Q", data_set, property_types, simulation_params),
-        get_model("UA", data_set, property_types, simulation_params),
+        get_2clj_model("AUA", data_set, property_types, simulation_params),
+        get_2clj_model("AUA+Q", data_set, property_types, simulation_params),
+        get_2clj_model("UA", data_set, property_types, simulation_params),
     ]
+
+    for mean, model in zip(maximum_a_posteriori, sub_models):
+        print(model.evaluate_log_posterior(mean))
 
     model_collection = TwoCenterLJModelCollection(
         "2CLJ Models", sub_models, mapping_distributions

--- a/studies/samplers/run.py
+++ b/studies/samplers/run.py
@@ -4,27 +4,8 @@ import numpy
 
 from bayesiantesting.kernels import MCMCSimulation
 from bayesiantesting.kernels.samplers import NUTS, MetropolisSampler
-from bayesiantesting.models import Model, ModelCollection
-from bayesiantesting.utils import distributions
-
-
-class GaussianModel(Model):
-    """A representation of the two-center Lennard-Jones model, which
-    can be evaluated using a surrogate model against a `NISTDataSet`.
-    """
-
-    def __init__(self, name, prior_settings, loc, scale):
-
-        super().__init__(name, prior_settings, {})
-
-        self._loc = loc
-        self._scale = scale
-
-    def evaluate_log_likelihood(self, parameters):
-        return distributions.Normal(self._loc, self._scale).log_pdf(parameters)
-
-    def compute_percentage_deviations(self, parameters):
-        return {}
+from bayesiantesting.models import ModelCollection
+from bayesiantesting.models.continuous import GaussianModel
 
 
 def main():

--- a/studies/ti/gaussian.py
+++ b/studies/ti/gaussian.py
@@ -8,29 +8,8 @@ Created on Thu Oct 31 14:42:37 2019
 
 import numpy
 
-# from bayesiantesting.kernels import MCMCSimulation
 from bayesiantesting.kernels.bayes import ThermodynamicIntegration
-from bayesiantesting.models import Model
-from bayesiantesting.utils import distributions
-
-
-class GaussianModel(Model):
-    """A representation of the two-center Lennard-Jones model, which
-    can be evaluated using a surrogate model against a `NISTDataSet`.
-    """
-
-    def __init__(self, name, prior_settings, loc, scale):
-
-        super().__init__(name, prior_settings, {})
-
-        self._loc = loc
-        self._scale = scale
-
-    def evaluate_log_likelihood(self, parameters):
-        return distributions.Normal(self._loc, self._scale).log_pdf(parameters)
-
-    def compute_percentage_deviations(self, parameters):
-        return {}
+from bayesiantesting.models.continuous import GaussianModel
 
 
 def main():

--- a/studies/ti/gaussian.py
+++ b/studies/ti/gaussian.py
@@ -32,7 +32,7 @@ def main():
         output_directory_path="gaussian",
     )
 
-    _, integral, error = simulation.run(initial_parameters, number_of_threads=4)
+    _, integral, error = simulation.run(initial_parameters, number_of_processes=4)
 
     print(f"Final Integral:", integral, " +/- ", error)
     print("==============================")

--- a/studies/utilities.py
+++ b/studies/utilities.py
@@ -103,7 +103,7 @@ def generate_initial_parameters(model):
 
     counter = 0
 
-    while numpy.isinf(initial_log_p) and counter < 5000:
+    while numpy.isinf(initial_log_p) and counter < 10000:
 
         initial_parameters = model.sample_priors()
         initial_log_p = model.evaluate_log_posterior(initial_parameters)

--- a/studies/utilities.py
+++ b/studies/utilities.py
@@ -1,17 +1,8 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-"""
-Created on Thu Oct 31 14:42:37 2019
-
-@author: owenmadin
-"""
-
 import numpy
 import yaml
 
 from bayesiantesting import unit
 from bayesiantesting.datasets.nist import NISTDataSet, NISTDataType
-from bayesiantesting.kernels.bayes import ThermodynamicIntegration
 from bayesiantesting.models.continuous import TwoCenterLJModel
 from bayesiantesting.surrogates import StollWerthSurrogate
 
@@ -26,13 +17,16 @@ def parse_input_yaml(filepath):
     return simulation_params
 
 
-def prepare_data(simulation_params):
+def prepare_data(simulation_params, compound=None):
     """From input parameters, pull appropriate experimental data and
     uncertainty information.
     """
 
+    if compound is None:
+        compound = simulation_params["compound"]
+
     # Retrieve the constants and thermophysical data
-    data_set = NISTDataSet(simulation_params["compound"])
+    data_set = NISTDataSet(compound)
 
     # Filter the data to selected conditions.
     minimum_temperature = (
@@ -63,7 +57,7 @@ def prepare_data(simulation_params):
     return data_set, property_types
 
 
-def get_model(model_name, data_set, property_types, simulation_params):
+def get_2clj_model(model_name, data_set, property_types, simulation_params):
 
     priors = {
         "epsilon": simulation_params["priors"]["epsilon"],
@@ -102,41 +96,28 @@ def get_model(model_name, data_set, property_types, simulation_params):
     return model
 
 
-def main():
+def generate_initial_parameters(model):
 
-    simulation_params = parse_input_yaml("basic_run.yaml")
+    initial_log_p = -numpy.inf
+    initial_parameters = None
 
-    # Load the data.
-    data_set, property_types = prepare_data(simulation_params)
+    counter = 0
 
-    # Set some reasonable initial parameters:
-    initial_parameters = {
-        "UA": numpy.array([100.0, 0.35]),
-        "AUA": numpy.array([120.0, 0.35, 0.12]),
-        "AUA+Q": numpy.array([140.0, 0.35, 0.26, 0.05]),
-    }
+    while numpy.isinf(initial_log_p) and counter < 5000:
 
-    # Build the model / models.
-    for model_name in initial_parameters:
+        initial_parameters = model.sample_priors()
+        initial_log_p = model.evaluate_log_posterior(initial_parameters)
 
-        model = get_model(model_name, data_set, property_types, simulation_params)
+        counter += 1
 
-        simulation = ThermodynamicIntegration(
-            legendre_gauss_degree=20,
-            model=model,
-            warm_up_steps=int(simulation_params["steps"] * 0.2),
-            steps=simulation_params["steps"],
-            discard_warm_up_data=True,
-            output_directory_path=f"ti_{model_name}",
+    initial_parameters = model.find_maximum_a_posteriori(initial_parameters)
+    initial_log_p = model.evaluate_log_posterior(initial_parameters)
+
+    if numpy.isnan(initial_log_p) or numpy.isinf(initial_log_p):
+
+        raise ValueError(
+            "The initial values could not be set without yielding "
+            "a NaN / inf log posterior"
         )
 
-        _, integral, error = simulation.run(
-            initial_parameters[model_name], number_of_processes=20
-        )
-
-        print(f"{model_name} Final Integral:", integral, " +/- ", error)
-        print("==============================")
-
-
-if __name__ == "__main__":
-    main()
+    return initial_parameters


### PR DESCRIPTION
## Description
This PR extends the existing bayes model evidence calculations to be able to calculate the 'free energy' difference between a model posterior and an arbitrary distribution, rather than just the prior. This is useful in cases whereby the posterior cannot be smoothly interpolated into the prior e.g. in cases where the likelihood function has singularities as is the case with the 2CLJ model.

## Status
- [X] Ready to go